### PR TITLE
Improve current EXIF processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ migrate/importNextGen/
 migrate/importNextGen.zip
 src/CommunityVoices/Public/outbox.php
 src/CommunityVoices/App/Website/main_db.php
+composer.phar

--- a/src/CommunityVoices/App/Website/Presentation/SinglePane.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/SinglePane.xslt
@@ -76,7 +76,7 @@
             ]]>
             </script>
             <xsl:if test="extraJS != ''">
-                <script src="https://environmentaldashboard.org/community-voices/public/js/{extraJS}.js"></script>
+                <script src="/public/js/{extraJS}.js"></script>
             </xsl:if>
         </body>
     </html>

--- a/src/CommunityVoices/Public/js/image-collection.js
+++ b/src/CommunityVoices/Public/js/image-collection.js
@@ -1,6 +1,6 @@
 function sortCheckboxes($e) {
   var sorted = [];
-  $e.children().each(function(i) { 
+  $e.children().each(function(i) {
     var $input = $(this).children('input');
     var $label = $(this).children('label');
     sorted.push({
@@ -40,7 +40,7 @@ $('.sorted-checkboxes').each(function(i, container){
   $(container).each(function(j, checkboxes) {
     var $checkboxes = $(checkboxes);
     $checkboxes.html(sortCheckboxes($checkboxes)); // sort once initially
-    $checkboxes.on("change", function() { 
+    $checkboxes.on("change", function() {
       $(this).html(sortCheckboxes($(this))); // resort every time checkbox checked
     });
   });
@@ -82,7 +82,7 @@ $('#file').on('change', function(e) {
 
   var file = this.files[0];
   var reader = new FileReader();
-  reader.onloadend = function() {
+	reader.onloadend = function() {
     $.post( "https://environmentaldashboard.org/community-voices/public/exif.php", { image: reader.result }, function( exif ) {
       $('#dateTaken').val(exif.DateTime);
       $('#title').val(exif.FileName);
@@ -90,5 +90,3 @@ $('#file').on('change', function(e) {
   }
   reader.readAsDataURL(file); // https://stackoverflow.com/a/20285053/2624391
 });
-
-

--- a/src/CommunityVoices/Public/js/image-collection.js
+++ b/src/CommunityVoices/Public/js/image-collection.js
@@ -89,19 +89,15 @@ $('#file').on('change', function(e) {
 		$.post("/public/exif.php", { image: reader.result }, function( exif ) {
 			// exif.DateTime will be the date of photo taken, set by a camera
 			// if it does not exist, this may be a screenshot
-			// we will default to the file time if it is set, otherwise
-			// the current time
-			var date = null;
-			if (exif.DateTime) {
-				date = exif.DateTime;
-			} else {
-				if (exif.FileDateTime > 0)
-					date = exif.FileDateTime;
-				else
-					date = new Date(Date.now()).toLocaleString();
-			}
+			// we will default to the file time if it is set
+			// to anything other than 0
+			var date = exif.DateTime || exif.FileDateTime;
 
-			$('#dateTaken').val(date);
+			// date may equal 0, but we don't want to fill in
+			// with a value of 0
+			if (date != 0)
+				$('#dateTaken').val(date);
+
 			$('#title').val(names[0]);
 		}, "json").fail(function (r) {
 			// If we have no data, we will empty out our auto-filled data.

--- a/src/CommunityVoices/Public/js/image-collection.js
+++ b/src/CommunityVoices/Public/js/image-collection.js
@@ -91,7 +91,15 @@ $('#file').on('change', function(e) {
 			// if it does not exist, this may be a screenshot
 			// we will default to the file time if it is set, otherwise
 			// the current time
-			var date = exif.DateTime || (exif.FileDateTime > 0 ? exif.FileDateTime : new Date(Date.now()).toLocaleString());
+			var date = null;
+			if (exif.DateTime) {
+				date = exif.DateTime;
+			} else {
+				if (exif.FileDateTime > 0)
+					date = exif.FileDateTime;
+				else
+					date = new Date(Date.now()).toLocaleString();
+			}
 
 			$('#dateTaken').val(date);
 			$('#title').val(names[0]);


### PR DESCRIPTION
This is largely a precursor to the next steps on my end, which is implementing EXIF processing within our main Community Voices architecture (done; see `exif-server` branch) and then trying to use a JavaScript library to process EXIF data so that the server does nothing at all for this (next step for me).

The two (listed as three bullet points, but two things) main changes in this pull request:
- Allow local JavaScript development by pulling a relative source for `extraJS` as opposed to forcing to pull from `environmentaldashboard.org` - This is a hugely important change that I plan to extend to CSS etc.
- Local reference `public/exif.php` for accessing EXIF data from the server.
- I really wanted to fix all of these images having their date set to 0, which ends up being 1969 (see https://www.environmentaldashboard.org/community-voices/images/4204 as an example; created at is set correctly but its specific date in the admin photo view is so bad).  So, I decided on this stream of logic for what to set the photo date to by default:
If `exif.DateTime` exists, this photo was likely taken by a camera (it seems that cameras set that field).  So, we want to use that field if it exists for sure.
If it does not, the file may have some creation date attached to it.  This could be `exif.FileDateTime`.  This is less ideal, but still a good estimate of when it was taken.
Finally, if neither of these exist, I would say the current time of upload is a better estimate of when the photo was taken than 1969 (time = 0).
Maybe it's worth going in and reassigning some of these image dates in the database too, honestly.  Just scroll around https://www.environmentaldashboard.org/community-voices/images to see what I mean.

Basically, while working today I realized there's no reason this branch shouldn't be integrated asap; so just wondering of your thoughts on the changes.