### PR TITLE
Do not assume we have another quote in the system

### DIFF
--- a/src/CommunityVoices/App/Website/View/Quote.php
+++ b/src/CommunityVoices/App/Website/View/Quote.php
@@ -66,7 +66,7 @@ class Quote extends Component\View
             $nextQuoteXMLElement = new SimpleXMLElement(
                 $this->transcriber->toXml($boundaryQuotes['quoteCollection'][1])
             );
-        } else {
+        } else if (key_exists(0, $boundaryQuotes['quoteCollection'])) {
             // This logic is probably best kept out of a view.
             // TODO (but maybe it is fine in a view)
             $isPrev = $boundaryQuotes['quoteCollection'][0]['quote']['id'] < $quote->quote->id;


### PR DESCRIPTION
This is another step toward fixing the Cleveland problems.

When we have only a single quote in the database, we error because our code assumes we have at least 2 quotes in the database.