### PR TITLE
Remove most hardcoded links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 vendor/
 log/
 
+backup/
+
 composer.phar
 db.config
 
@@ -16,5 +18,6 @@ CV_Media/
 migrate/importNextGen/
 migrate/importNextGen.zip
 
-# Sam's code to push to both servers
+# Sam's various personal scripts
 pull-everywhere.sh
+run-cle-db.sh

--- a/src/CommunityVoices/App/Api/Component/Controller.php
+++ b/src/CommunityVoices/App/Api/Component/Controller.php
@@ -43,7 +43,7 @@ class Controller extends Component\SecuredComponent
     protected function send404()
     {
         http_response_code(404);
-        echo file_get_contents('https://environmentaldashboard.org/404');
+        echo file_get_contents('/404');
         exit;
     }
 }

--- a/src/CommunityVoices/App/Website/Finder/templates/matches-image-element.html.php
+++ b/src/CommunityVoices/App/Website/Finder/templates/matches-image-element.html.php
@@ -4,11 +4,11 @@
     <?php endif; ?>
 
     <p>
-        <img src="https://environmentaldashboard.org/community-voices/uploads/<?=$image->media_id ?>" width="100%">
+        <img src="/community-voices/uploads/<?=$image->media_id ?>" width="100%">
     <p>
 
     <p>Image ID: <strong><?=$image->media_id ?></strong></p>
     <p>Hash: <strong><?=strtolower($image->conv_hash) ?></strong></p>
     <p>Distance: <strong><?=$image->d ?></strong></p>
-    <p><a href="https://environmentaldashboard.org/community-voices/images/<?=$image->media_id ?>" target="_blank">Open image in new tab</a></p>
+    <p><a href="/community-voices/images/<?=$image->media_id ?>" target="_blank">Open image in new tab</a></p>
 </div>

--- a/src/CommunityVoices/App/Website/Presentation/Module/Article.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/Article.xslt
@@ -38,12 +38,12 @@
 								  </ol> -->
 								  <div class="carousel-inner">
 								    <div class="carousel-item active">
-									    <img class="d-block w-100" src="https://environmentaldashboard.org/community-voices/uploads/{domain/article/image}" alt="{title}" />
+									    <img class="d-block w-100" src="/community-voices/uploads/{domain/article/image}" alt="{title}" />
 								    </div>
 								    <xsl:for-each select="domain/relatedSlides/media_id">
 								    	<div class="carousel-item">
 								    		<div class="embed-responsive embed-responsive-16by9">
-												  <iframe class="embed-responsive-item" src="https://environmentaldashboard.org/community-voices/slides/{.}"></iframe>
+												  <iframe class="embed-responsive-item" src="/community-voices/slides/{.}"></iframe>
 												</div>
 									    </div>
 										</xsl:for-each>

--- a/src/CommunityVoices/App/Website/Presentation/Module/ArticleCollection.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/ArticleCollection.xslt
@@ -147,7 +147,7 @@
 
                   <ul class="list-unstyled">
                     <li class="media">
-                      <img class="mr-3" src="https://environmentaldashboard.org/community-voices/uploads/{image}" alt="{title}" style="width:200px" />
+                      <img class="mr-3" src="/community-voices/uploads/{image}" alt="{title}" style="width:200px" />
                       <div class="media-body">
                         <h5 class="mt-0 mb-1">
                           <xsl:value-of select='title' />

--- a/src/CommunityVoices/App/Website/Presentation/Module/Form/ImageUpdate.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/Form/ImageUpdate.xslt
@@ -10,7 +10,7 @@
         <div class="col-12">
 
           <div class="mb-2">
-            <img src="https://environmentaldashboard.org/community-voices/uploads/{domain/image/id}" alt="{domain/image/title}" id="cropper-img" style="width:80%;margin:0 auto;" class="mt-2 d-block" />
+            <img src="/community-voices/uploads/{domain/image/id}" alt="{domain/image/title}" id="cropper-img" style="width:80%;margin:0 auto;" class="mt-2 d-block" />
           </div>
 
           <div style="max-width:400px;margin: 0 auto">

--- a/src/CommunityVoices/App/Website/Presentation/Module/Form/SlideUpload.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/Form/SlideUpload.xslt
@@ -168,7 +168,7 @@
                   <iframe class="embed-responsive-item" id="preview" src="/community-voices/slides/{domain/slide/id}"></iframe>
                 </xsl:when>
                 <xsl:otherwise>
-                  <iframe class="embed-responsive-item" id="preview" src="https://environmentaldashboard.org/community-voices/slides/12"></iframe>
+                  <iframe class="embed-responsive-item" id="preview" src="/community-voices/slides/12"></iframe>
                 </xsl:otherwise>
               </xsl:choose>
             </div></div>

--- a/src/CommunityVoices/App/Website/Presentation/Module/Image.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/Image.xslt
@@ -55,7 +55,7 @@
           </xsl:choose>
           <div class="card mb-3">
             <img class="card-img-top">
-              <xsl:attribute name="src">https://environmentaldashboard.org/community-voices/uploads/<xsl:value-of select='domain/image/id' /></xsl:attribute>
+              <xsl:attribute name="src">/community-voices/uploads/<xsl:value-of select='domain/image/id' /></xsl:attribute>
               <xsl:attribute name="alt"><xsl:value-of select='domain/image/title' /></xsl:attribute>
             </img>
             <div class="card-body">
@@ -104,9 +104,9 @@
             <xsl:when test="domain/slideId != ''">
               <xsl:attribute name="class">col-sm-4</xsl:attribute>
               <h4>Content featuring this image</h4>
-              <a href='https://environmentaldashboard.org/community-voices/slides/{domain/slideId}'>
+              <a href='/community-voices/slides/{domain/slideId}'>
                 <div class="embed-responsive embed-responsive-16by9 mb-4">
-                  <iframe class="embed-responsive-item" style="pointer-events: none;" src="https://environmentaldashboard.org/community-voices/slides/{domain/slideId}"></iframe>
+                  <iframe class="embed-responsive-item" style="pointer-events: none;" src="/community-voices/slides/{domain/slideId}"></iframe>
                 </div>
               </a>
               <p>

--- a/src/CommunityVoices/App/Website/Presentation/Module/ImageCollection.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/ImageCollection.xslt
@@ -296,7 +296,7 @@
                             <xsl:attribute name="alt"><xsl:value-of select='title' /></xsl:attribute>
 							<xsl:attribute name="onerror">
 								this.onerror = null;
-								this.src = "https://environmentaldashboard.org/community-voices/uploads/<xsl:value-of select='id' />?max_width=325";
+								this.src = "/community-voices/uploads/<xsl:value-of select='id' />?max_width=325";
 							</xsl:attribute>
                           </img>
                         </a>
@@ -403,7 +403,7 @@
                     <a href="images/{id}">
                       <div class="image">
                         <img>
-                          <xsl:attribute name="src">https://environmentaldashboard.org/community-voices/uploads/<xsl:value-of select='id' /></xsl:attribute>
+                          <xsl:attribute name="src">/community-voices/uploads/<xsl:value-of select='id' /></xsl:attribute>
                           <xsl:attribute name="alt"><xsl:value-of select='title' /></xsl:attribute>
                           <xsl:attribute name="class">card-img</xsl:attribute>
                         </img>

--- a/src/CommunityVoices/App/Website/Presentation/Module/Landing.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/Landing.xslt
@@ -35,14 +35,14 @@
                 <xsl:when test="$i = 1">
                   <div class="carousel-item active">
                     <div class="embed-responsive embed-responsive-16by9 mb-4">
-                      <iframe class="embed-responsive-item" id="slide{$i}" style="pointer-events: none;" src="https://environmentaldashboard.org/community-voices/slides/{id}"></iframe>
+                      <iframe class="embed-responsive-item" id="slide{$i}" style="pointer-events: none;" src="/community-voices/slides/{id}"></iframe>
                     </div>
                   </div>
                 </xsl:when>
                 <xsl:otherwise>
                   <div class="carousel-item">
                     <div class="embed-responsive embed-responsive-16by9 mb-4">
-                      <iframe class="embed-responsive-item" id="slide{$i}" style="pointer-events: none;" src="https://environmentaldashboard.org/community-voices/slides/{id}"></iframe>
+                      <iframe class="embed-responsive-item" id="slide{$i}" style="pointer-events: none;" src="/community-voices/slides/{id}"></iframe>
                     </div>
                   </div>
                 </xsl:otherwise>

--- a/src/CommunityVoices/App/Website/Presentation/Module/Quote.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/Quote.xslt
@@ -141,9 +141,9 @@
 	            <xsl:when test="domain/slideId != ''">
 	            	<xsl:attribute name="class">col-sm-4</xsl:attribute>
 	              <h4>Content featuring this quote</h4>
-	              <a href='https://environmentaldashboard.org/community-voices/slides/{domain/slideId}'>
+	              <a href='/community-voices/slides/{domain/slideId}'>
 	                <div class="embed-responsive embed-responsive-16by9 mb-4">
-	                  <iframe class="embed-responsive-item" style="pointer-events: none;" src="https://environmentaldashboard.org/community-voices/slides/{domain/slideId}"></iframe>
+	                  <iframe class="embed-responsive-item" style="pointer-events: none;" src="/community-voices/slides/{domain/slideId}"></iframe>
 	                </div>
 	              </a>
 	              <p>

--- a/src/CommunityVoices/App/Website/Presentation/Module/Slide.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/Slide.xslt
@@ -8,7 +8,7 @@
 
   <xsl:template match="/package">
     <div style="display: flex;align-items:center;height: 86vh">
-      <img src="https://environmentaldashboard.org/community-voices/uploads/{domain/slide/image/image/id}" alt="{domain/slide/image/image/title}" style="flex-shrink: 0;width: auto;max-height: 86vh;max-width:70vw;max-height:100%" />
+      <img src="/community-voices/uploads/{domain/slide/image/image/id}" alt="{domain/slide/image/image/title}" style="flex-shrink: 0;width: auto;max-height: 86vh;max-width:70vw;max-height:100%" />
       <h1 style="{concat('color:#fff;padding:3vw;font-size:', domain/slide/font_size, 'vw;font-weight:400')}">
         <xsl:choose>
           <xsl:when test="domain/slide/quote/quote/quotationMarks = ''">

--- a/src/CommunityVoices/Model/Service/Registration.php
+++ b/src/CommunityVoices/Model/Service/Registration.php
@@ -131,7 +131,7 @@ class Registration
 
         $message->setTo($email);
         $message->setSubject("You're invited to be a Community Voices {$position}");
-        $message->setBody("<p>You have been invited to create a new {$position} account. <a href='https://environmentaldashboard.org/community-voices/register?token={$token}'>Click here</a> to complete the registration process.</p>");
+        $message->setBody("<p>You have been invited to create a new {$position} account. <a href='/community-voices/register?token={$token}'>Click here</a> to complete the registration process.</p>");
 
         $this->mailer->send($message);
     }

--- a/src/CommunityVoices/Public/digital-signage.php
+++ b/src/CommunityVoices/Public/digital-signage.php
@@ -37,7 +37,7 @@ $sorted_rows = array_fill_keys($gallery_names, []); // list of urls, each duplic
 $num_urls = 0;
 foreach ($dbHandler->query($sql) as $row) {
     for ($i=0; $i < $row['probability']; $i++) {
-        $sorted_rows[$row['content_category_id']][] = "https://environmentaldashboard.org/community-voices/slides/{$row['media_id']}";
+        $sorted_rows[$row['content_category_id']][] = "/community-voices/slides/{$row['media_id']}";
     }
     $num_urls += $row['probability'];
 }

--- a/src/CommunityVoices/Public/js/create-slide.js
+++ b/src/CommunityVoices/Public/js/create-slide.js
@@ -318,7 +318,7 @@ function getImage(page) {
         var html = '<div class="card-columns">';
         $.each(data['imageCollection'], function(index, element) {
             if (typeof element === 'object') {
-                html += '<div class="card bg-dark text-white ajax-image" data-id="'+element['image']['id']+'"><img class="card-img" src="https://environmentaldashboard.org/community-voices/uploads/'+element['image']['id']+'" alt="'+element['image']['title']+'" /></div>';
+                html += '<div class="card bg-dark text-white ajax-image" data-id="'+element['image']['id']+'"><img class="card-img" src="/community-voices/uploads/'+element['image']['id']+'" alt="'+element['image']['title']+'" /></div>';
             }
         });
         html += '</div>';

--- a/src/CommunityVoices/Public/js/image-update.js
+++ b/src/CommunityVoices/Public/js/image-update.js
@@ -30,7 +30,7 @@ function enable_cropper() {
 }
 enable_cropper();
 
-const base = 'https://environmentaldashboard.org/community-voices/uploads/';
+const base = '/community-voices/uploads/';
 var rect = {crop_x: 0, crop_y: 0, crop_height: 0, crop_width:0};
 function load_uncropped(e) {
   var text = e.firstChild.nodeValue,


### PR DESCRIPTION
These remain, and should probably be removed by merging into Community Voices - this does cause duplication though, so maybe require running within a greater ED architecture?  Although, the Cleveland instance seeks to break this, so maybe these should be moved into the Community Voices codebase?  Not sure exactly, but I lean toward the second.  It's an issue for later, though.

<img width="938" alt="Screen Shot 2020-02-06 at 9 27 21 PM" src="https://user-images.githubusercontent.com/3077078/73996122-bdcbf000-4928-11ea-932b-d9e60ec4c98d.png">
