### PR TITLE
Allow anyone to write to the log

### DIFF
--- a/build/init.sh
+++ b/build/init.sh
@@ -16,3 +16,4 @@ service postfix start
 # Make sure log/access.log exists
 mkdir -p /var/www/html/log
 touch /var/www/html/log/access.log
+chmod a+w /var/www/html/log/access.log


### PR DESCRIPTION
Trello: https://trello.com/c/oGPmscAF/119-cv-make-sure-that-the-dockerfile-ensures-that-anyone-can-write-to-the-log

Otherwise, the result here is that we solve no problems - anytime we need to write to the log we still cannot.  I did not know what exact permission I needed to target in order to fix this issue, so `a+w` was the easiest way for me to target all possibilities.

My question for review is more starting to be if I can continue to have this build script separate over lines like a normal script or if I need to use the `&&` operator more because this is being fed into a Dockerfile.