### PR TITLE
Fix image edit crash

### DIFF
--- a/src/CommunityVoices/App/Website/Controller/Image.php
+++ b/src/CommunityVoices/App/Website/Controller/Image.php
@@ -50,6 +50,8 @@ class Image
         //$this->imageAPIController->getImage($request);
     }
 
+    // I had originally thought this was only through AJAX, but it is instead only
+    // mostly through AJAX.
     public function postImageUpdate($request)
     {
         //$this->imageAPIController->postImageUpdate($request);
@@ -59,6 +61,7 @@ class Image
         return $errors;
     }
 
+    // Is this ever accessed not through AJAX?
     public function postImageDelete($request)
     {
         //$this->imageAPIController->postImageDelete($request);

--- a/src/CommunityVoices/App/Website/Controller/Image.php
+++ b/src/CommunityVoices/App/Website/Controller/Image.php
@@ -53,6 +53,10 @@ class Image
     public function postImageUpdate($request)
     {
         //$this->imageAPIController->postImageUpdate($request);
+
+        $id = $request->attributes->get('id');
+        $errors = $this->apiProvider->postJson("/images/{$id}/edit/authenticate", $request);
+        return $errors;
     }
 
     public function postImageDelete($request)

--- a/src/CommunityVoices/App/Website/View/Image.php
+++ b/src/CommunityVoices/App/Website/View/Image.php
@@ -286,7 +286,7 @@ class Image extends Component\View
 
         $tags = $this->apiProvider->getJson('/tags', $request);
         $tagXMLElement = new SimpleXMLElement(
-            $this->transcriber->toXml($tags->getEntry('tag')[0]->toArray())
+            $this->transcriber->toXml($tags)
         );
 
         $selectedTagString = ',';


### PR DESCRIPTION
This is indeed a result of a missed exchange of code when code of a bad pattern was being replaced.  I missed this because it is a path to edit I did not even know existed.