### PR TITLE
Notify when we cannot delete a content category due to it being attac…

### DIFF
--- a/src/CommunityVoices/App/Api/View/ContentCategory.php
+++ b/src/CommunityVoices/App/Api/View/ContentCategory.php
@@ -64,7 +64,6 @@ class ContentCategory extends Component\View
 
     protected function postContentCategoryDelete()
     {
-        // dummy response
-        return new HttpFoundation\JsonResponse(true);
+        return $this->errorsResponse('contentCategoryDelete');
     }
 }

--- a/src/CommunityVoices/App/Website/Component/ApiProvider.php
+++ b/src/CommunityVoices/App/Website/Component/ApiProvider.php
@@ -54,7 +54,7 @@ class ApiProvider
                 foreach ($file as $index => $f) {
                     $data["{$key}[{$index}]"] = new \CURLFile($f->getPathName(), $f->getMimeType());
                 }
-            } else {
+            } else if (!is_null($file)) {
                 $data[$key] = new \CURLFile($file->getPathName(), $file->getMimeType());
             }
         }

--- a/src/CommunityVoices/App/Website/Presentation/Module/Form/ContentCategory.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/Form/ContentCategory.xslt
@@ -1,15 +1,12 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     version="1.0">
 
+    <xsl:import href="../../Component/Card.xslt" />
     <xsl:output method="html" indent="yes" omit-xml-declaration="yes" />
 
     <xsl:template match="/form">
         <div class="row" style="padding:15px;">
             <div class="col-12">
-                <xsl:if test="@failure">
-                    <p>Label missing.</p>
-                </xsl:if>
-
                 <form method='post' id="ccform" style="max-width:400px;margin: 0 auto" enctype='multipart/form-data'>
                     <xsl:attribute name="action">
                         <xsl:choose>
@@ -21,6 +18,23 @@
                             </xsl:otherwise>
                         </xsl:choose>
                     </xsl:attribute>
+
+                    <xsl:if test="domain/errors != ''">
+                        <xsl:variable name="errorsList">
+                            <xsl:for-each select="domain/errors/*">
+                                <item><xsl:value-of select="."/></item>
+                            </xsl:for-each>
+                            <xsl:if test="@failure">
+                                <item>Label missing.</item>
+                            </xsl:if>
+                        </xsl:variable>
+                        <xsl:call-template name="card">
+                            <xsl:with-param name="title">
+                              Some errors prevented action
+                            </xsl:with-param>
+                            <xsl:with-param name="message" select="$errorsList"/>
+                        </xsl:call-template>
+                    </xsl:if>
 
                     <div class="custom-file">
                       <label for="file" class="custom-file-label">Image</label>

--- a/src/CommunityVoices/App/Website/View/ContentCategory.php
+++ b/src/CommunityVoices/App/Website/View/ContentCategory.php
@@ -133,7 +133,7 @@ class ContentCategory extends Component\View
         return $response;
     }
 
-    public function getContentCategoryUpdate($request)
+    public function getContentCategoryUpdate($request, $errors = self::ERRORS_DEFAULT)
     {
         $paramXML = new Helper\SimpleXMLElementExtension('<form/>');
 
@@ -145,8 +145,13 @@ class ContentCategory extends Component\View
                 )
             );
 
+            $errorsXMLElement = new SimpleXMLElement(
+                $this->transcriber->toXml($errors)
+            );
+
             $packagedContentCategory = $paramXML->addChild('domain');
             $packagedContentCategory->adopt($contentCategoryXMLElement);
+            $packagedContentCategory->adopt($errorsXMLElement);
         } catch (\Error $e) {
             // This happens when we are uploading, not updating.
             // Nothing is very big of a deal in this case.
@@ -185,8 +190,12 @@ class ContentCategory extends Component\View
         return $response;
     }
 
-    public function postContentCategoryDelete($request)
+    public function postContentCategoryDelete($request, $errors = self::ERRORS_DEFAULT)
     {
+        if (!empty($errors->errors)) {
+            return $this->getContentCategoryUpdate($request, $errors);
+        }
+
         $response = new HttpFoundation\RedirectResponse(
             dirname(dirname($request->headers->get('referer')))
         );


### PR DESCRIPTION
…hed to slides

This catches the SQL error thrown when we delete a content category that has slides attached and notifies the user of it.  I think it could be better to find slides and do the check ourselves, but possibly catching the SQL error could be more efficient?  Not sure.