### PR TITLE
Lowers max-height of content-category image

### DIFF
--- a/src/CommunityVoices/App/Website/Presentation/Module/ContentCategory.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/ContentCategory.xslt
@@ -7,7 +7,7 @@
     <div>
         <xsl:attribute name="style">width:100%;background:<xsl:value-of select="domain/contentCategory/color" />;position:absolute;bottom:0;height:14vh;text-transform:uppercase;color:#fff;font-size:8vh;line-height:14vh;font-weight:700;padding-left:1vw</xsl:attribute>
         <xsl:value-of select="domain/contentCategory/label" />
-      <img src="" alt="" style="position:absolute;right:3vw;bottom:2vw;max-width:25vw;max-height:16vh">
+      <img src="" alt="" style="position:absolute;right:3vw;bottom:2vw;max-width:25vw;max-height:25vh">
         <xsl:attribute name="src">/community-voices/uploads/<xsl:value-of select="domain/contentCategory/image/image/id" /></xsl:attribute>
       </img>
     </div>

--- a/src/CommunityVoices/App/Website/Presentation/Module/ContentCategory.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/ContentCategory.xslt
@@ -7,7 +7,7 @@
     <div>
         <xsl:attribute name="style">width:100%;background:<xsl:value-of select="domain/contentCategory/color" />;position:absolute;bottom:0;height:14vh;text-transform:uppercase;color:#fff;font-size:8vh;line-height:14vh;font-weight:700;padding-left:1vw</xsl:attribute>
         <xsl:value-of select="domain/contentCategory/label" />
-      <img src="" alt="" style="position:absolute;right:3vw;bottom:2vw;max-width:25vw;max-height:25vh">
+      <img src="" alt="" style="position:absolute;right:3vw;bottom:2vw;max-width:25vw;max-height:16vh">
         <xsl:attribute name="src">/community-voices/uploads/<xsl:value-of select="domain/contentCategory/image/image/id" /></xsl:attribute>
       </img>
     </div>

--- a/src/CommunityVoices/App/Website/Presentation/Module/Slide.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/Slide.xslt
@@ -45,7 +45,7 @@
             </xsl:if>
             <xsl:value-of select="domain/slide/contentCategory/contentCategory/label" />
         </span>
-        <img alt="" style="position:absolute;right:3vw;bottom:2vw;max-width:25vw;max-height:16vh;">
+        <img alt="" style="position:absolute;right:3vw;bottom:2vw;max-width:25vw;max-height:25vh;">
           <xsl:attribute name="src">/community-voices/uploads/<xsl:value-of select="domain/slide/contentCategory/contentCategory/image/image/id" /></xsl:attribute>
         </img>
     </div>

--- a/src/CommunityVoices/App/Website/Presentation/Module/Slide.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/Slide.xslt
@@ -9,7 +9,7 @@
   <xsl:template match="/package">
     <div style="display: flex;align-items:center;height: 86vh">
       <img src="/community-voices/uploads/{domain/slide/image/image/id}" alt="{domain/slide/image/image/title}" style="flex-shrink: 0;width: auto;max-height: 86vh;max-width:70vw;max-height:100%" />
-      <h1 style="{concat('color:#fff;padding:3vw;font-size:', domain/slide/font_size, 'vw;font-weight:400')}">
+      <h1 style="color:#fff;padding:3vw;font-size:2.8vw;font-weight:400;margin-bottom: 10vh;margin-top: 0px;">
         <xsl:choose>
           <xsl:when test="domain/slide/quote/quote/quotationMarks = ''">
             <xsl:value-of select="domain/slide/quote/quote/text"></xsl:value-of>

--- a/src/CommunityVoices/App/Website/Presentation/Module/Slide.xslt
+++ b/src/CommunityVoices/App/Website/Presentation/Module/Slide.xslt
@@ -45,7 +45,7 @@
             </xsl:if>
             <xsl:value-of select="domain/slide/contentCategory/contentCategory/label" />
         </span>
-        <img alt="" style="position:absolute;right:3vw;bottom:2vw;max-width:25vw;max-height:25vh;">
+        <img alt="" style="position:absolute;right:3vw;bottom:2vw;max-width:25vw;max-height:16vh;">
           <xsl:attribute name="src">/community-voices/uploads/<xsl:value-of select="domain/slide/contentCategory/contentCategory/image/image/id" /></xsl:attribute>
         </img>
     </div>

--- a/src/CommunityVoices/Public/js/create-slide.js
+++ b/src/CommunityVoices/Public/js/create-slide.js
@@ -281,7 +281,7 @@ function renderSlide(quote_text, attribution, image, ccid, logo) {
             (logo ? '<img src="/community-voices/uploads/' + logo + '" alt="" style="position:absolute;left:2vw;bottom:2vw;width:10vw;height:auto;" />' : '')+
             (logo ? '<span style="position:absolute;left:14vw;">' : '')+cc.label+(logo ? '</span>' : '')+
             '<img src="/community-voices/uploads/'+
-            cc.image.image.id+'" alt="" style="position:absolute;right:3vw;bottom:2vw;max-width:25vw;max-height:25vh" /></div></body></html>';
+            cc.image.image.id+'" alt="" style="position:absolute;right:3vw;bottom:2vw;max-width:25vw;max-height:16vh" /></div></body></html>';
         iframe.src = 'data:text/html;charset=utf-8,' + encodeURIComponent(head + body);
     });
 }

--- a/src/CommunityVoices/Public/js/create-slide.js
+++ b/src/CommunityVoices/Public/js/create-slide.js
@@ -274,14 +274,14 @@ function renderSlide(quote_text, attribution, image, ccid, logo) {
         var cc = data.contentCategory;
         var head = '<html><head><base href="' + window.location.origin + '" /><meta charset="utf-8" /><style>* { box-sizing:border-box }html, body { height: 100%; font-family:Comfortaa, sans-serif; }</style><link href="https://fonts.googleapis.com/css?family=Comfortaa:400,700" rel="stylesheet" /></head><body style="background:#000;margin:0;padding:0;">';
         var body = '<div style="display: flex;align-items:center;max-height:100%"><div><img src="/community-voices/uploads/'+
-            image+'" style="flex-shrink: 0;width: auto;height: 86vh;max-width:70vw;max-height:100%" /></div><h1 style="color:#fff;padding:3vw;font-size:3vw;font-weight:400">'+
+            image+'" style="flex-shrink: 0;width: auto;height: 86vh;max-width:70vw;max-height:100%" /></div><h1 style="color:#fff;padding:3vw;font-size:2.8vw;font-weight:400;margin-bottom: 10vh;margin-top: 0px;">'+
             quote_text+'<div style="font-size:2vw;margin-top:2vw">&#x2014; '+
             attribution+'</div></h1></div><div style="width:100%;background:'+
             cc.color+';position:absolute;bottom:0;height:14vh;text-transform:uppercase;color:#fff;font-size:7vh;line-height:14vh;font-weight:700;padding-left:1vw">'+
             (logo ? '<img src="/community-voices/uploads/' + logo + '" alt="" style="position:absolute;left:2vw;bottom:2vw;width:10vw;height:auto;" />' : '')+
             (logo ? '<span style="position:absolute;left:14vw;">' : '')+cc.label+(logo ? '</span>' : '')+
             '<img src="/community-voices/uploads/'+
-            cc.image.image.id+'" alt="" style="position:absolute;right:3vw;bottom:2vw;max-width:25vw;max-height:16vh" /></div></body></html>';
+            cc.image.image.id+'" alt="" style="position:absolute;right:3vw;bottom:2vw;max-width:25vw;max-height:25vh" /></div></body></html>';
         iframe.src = 'data:text/html;charset=utf-8,' + encodeURIComponent(head + body);
     });
 }

--- a/upload-prod.sh
+++ b/upload-prod.sh
@@ -7,4 +7,4 @@ else
   dump=db/dump.sql
 fi
 
-docker exec cv-mysql mysql community_voices < $dump
+docker exec -i cv-mysql mysql community_voices < $dump


### PR DESCRIPTION
This PR is a quick fix to content category images overlapping text on slides. Max-height for said images was changed to 16vh as suggested by @Sammidysam.

https://www.notion.so/John-sent-an-email-about-text-overlap-and-remove-that-overlap-10e5869194bc4105b3b1b9f4b2a28060