### PR TITLE
Fix issue with being unable to upload content-categories/images

### DIFF
--- a/build/init.sh
+++ b/build/init.sh
@@ -21,6 +21,7 @@ chmod a+w /var/www/html/log/access.log
 
 # Make sure CV_Media/images exists
 mkdir -p /var/www/html/CV_Media/images
+chmod a+w /var/www/html/CV_Media/images
 
 # Load cron file
 crontab /var/www/html/crontab/crontab


### PR DESCRIPTION
This quick fix should fix the issue that prevents upload of new images/content-categories because of CV being unable to write to the `CV_Media/images` directory.