### PR TITLE
Slide edit permissions

### DIFF
--- a/src/CommunityVoices/App/Api/Component/Exception/AccessDenied.php
+++ b/src/CommunityVoices/App/Api/Component/Exception/AccessDenied.php
@@ -4,6 +4,9 @@ namespace CommunityVoices\App\Api\Component\Exception;
 
 class AccessDenied extends \Exception
 {
+    public const LOGGED_IN_MESSAGE = "Check the permissions of your user account.";
+    public const LOGGED_OUT_MESSAGE = "Please log in.";
+
     // Our message is constructed by the constructor itself.
     // We simply need an identity in order to establish what exactly
     // we are going to pass along as the message.
@@ -12,9 +15,9 @@ class AccessDenied extends \Exception
         $message = "You are not allowed to view this page.";
 
         if ($identity) {
-            $message .= "  Check the permissions of your user account.";
+            $message .= "  " . self::LOGGED_IN_MESSAGE;
         } else {
-            $message .= "  Please log in.";
+            $message .= "  " . self::LOGGED_OUT_MESSAGE;
         }
 
         // Our exception code will always be 0 (the second argument),

--- a/src/CommunityVoices/App/Website/Component/ApiProvider.php
+++ b/src/CommunityVoices/App/Website/Component/ApiProvider.php
@@ -2,6 +2,8 @@
 
 namespace CommunityVoices\App\Website\Component;
 
+use CommunityVoices\App\Api\Component\Exception\AccessDenied;
+
 class ApiProvider
 {
     public function getJson($path, $request, $debug = false)
@@ -29,6 +31,17 @@ class ApiProvider
         }
 
         $response = file_get_contents(getenv('API_URL') . $path, false, $context ?? null);
+
+        // Need to check if this is an access denied.
+        // It seems the JSON responses have two '\\', while the HTML responses have one.
+        if (
+            strpos($response, 'CommunityVoices\App\Api\Component\Exception\AccessDenied') !== false ||
+            strpos($response, 'CommunityVoices\\\App\\\Api\\\Component\\\Exception\\\AccessDenied') !== false
+        ) {
+            // Rather than passing the identity, we will just pass if the identity exists or not,
+            // as that is all that AccessDenied needs.
+            throw new AccessDenied(strpos($response, AccessDenied::LOGGED_IN_MESSAGE) !== false);
+        }
 
         if ($debug) {
             echo $response;

--- a/src/CommunityVoices/App/Website/Component/ApiProvider.php
+++ b/src/CommunityVoices/App/Website/Component/ApiProvider.php
@@ -109,6 +109,13 @@ class ApiProvider
         $result = curl_exec($ch);
         curl_close($ch);
 
+        if (
+            strpos($result, 'CommunityVoices\App\Api\Component\Exception\AccessDenied') !== false ||
+            strpos($result, 'CommunityVoices\\\App\\\Api\\\Component\\\Exception\\\AccessDenied') !== false
+        ) {
+            throw new AccessDenied(strpos($result, AccessDenied::LOGGED_IN_MESSAGE) !== false);
+        }
+
         if ($debug) {
             die();
         }


### PR DESCRIPTION
Addresses the issue from the Notion card below using code Sam wrote that was lost in limbo on another branch. If a non-admin user stumbles upon page they don't have permission to access, an "Access Denied" will now be shown instead of "scary orange error text".

https://www.notion.so/Access-Denied-page-for-the-edit-slides-pages-0528cee4696449baac5b9bb24d768023